### PR TITLE
Fix bug when a=0 and opts.plusZeroMinusZero=true

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,8 +85,7 @@ function eqInternal(a, b, opts, stackA, stackB, path, fails) {
       // NaN !== NaN
       return (a !== a) ? result(b !== b, REASON.NAN_NUMBER)
         // but treat `+0` vs. `-0` as not equal
-        : (a === 0 ? result((1 / a == 1 / b) || opts.plusZeroAndMinusZeroEqual, REASON.PLUS_0_AND_MINUS_0)
-        : result(a === b, REASON.EQUALITY));
+        : result(a === b, REASON.EQUALITY);
 
     case 'boolean':
     case 'string':


### PR DESCRIPTION
Before this commit, if `a=0` and `opts.plusZeroMinusZero=true`,
`eq()` would always return true, regardless of `b`

To fix it, the equality check on line 88 was removed, because it was not needed
normally, and was causing this bug when `opts.plusZeroMinusZero=true`.